### PR TITLE
Scrum 108 speakers presentation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,10 @@
+from .router import router
+
+def register_plugin():
+    print("Speaker management plugin registered.")
+
+def unregister_plugin():
+    print("Speaker management plugin unregistered.")
+
+REGISTER = register_plugin
+UNREGISTER = unregister_plugin

--- a/__init__.py
+++ b/__init__.py
@@ -6,13 +6,13 @@ from services.component_registry import ComponentRegistry
 
 def register_plugin():
     ComponentRegistry.register_component(SpeakerComponent)
-    print("Speaker presentation plugin registered")
+    print("Speaker presentation plugin registered.")
     return router
 
 
 def unregister_plugin():
     ComponentRegistry.unregister_component("SpeakerComponent")
-    print("Speaker presentation plugin unregistered")
+    print("Speaker presentation plugin unregistered.")
 
 
 REGISTER = register_plugin

--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,19 @@
+from utils.api import Router
 from .router import router
+from schemas.speaker_component import SpeakerComponent
+from services.component_registry import ComponentRegistry
+
 
 def register_plugin():
-    print("Speaker management plugin registered.")
+    ComponentRegistry.register_component(SpeakerComponent)
+    print("Speaker presentation plugin registered")
+    return router
+
 
 def unregister_plugin():
-    print("Speaker management plugin unregistered.")
+    ComponentRegistry.unregister_component("SpeakerComponent")
+    print("Speaker presentation plugin unregistered")
+
 
 REGISTER = register_plugin
 UNREGISTER = unregister_plugin

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 from utils.api import Router
 from .router import router
-from schemas.speaker_component import SpeakerComponent
+from .schemas.speaker_component import SpeakerComponent
 from services.component_registry import ComponentRegistry
 
 

--- a/models/speaker.py
+++ b/models/speaker.py
@@ -7,4 +7,4 @@ class Speaker(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     description = Column(Text, nullable=False)
-    image = Column(String)  # Pode ser URL ou nome do ficheiro
+    image = Column(String, nullable=False)  # Pode ser URL ou nome do ficheiro

--- a/models/speaker.py
+++ b/models/speaker.py
@@ -1,0 +1,10 @@
+from dependencies.database import Base
+from sqlalchemy import Column, Integer, String, Text
+
+class Speaker(Base):
+    __tablename__ = "speakers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=False)
+    image = Column(String)  # Pode ser URL ou nome do ficheiro

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+SQLAlchemy
+fastapi

--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,0 +1,7 @@
+from utils.api import Router
+from .speaker import router as speaker_router
+
+router = Router()
+router.include_router(speaker_router, "/speakers")
+
+__all__ = ["router"]

--- a/router/speaker.py
+++ b/router/speaker.py
@@ -1,0 +1,64 @@
+from fastapi import Depends, HTTPException, Path
+from utils.api import Router
+from sqlalchemy.orm import Session
+from dependencies.database import get_db
+from dependencies.auth import check_role
+from ..models.speaker import Speaker as SpeakerModel
+from ..schemas.speaker import SpeakerCreate, Speaker as SpeakerSchema
+
+router = Router()
+
+@router.post("/", response_model=SpeakerSchema)
+def create_speaker(
+    speaker: SpeakerCreate,
+    db: Session = Depends(get_db),
+    user: dict = Depends(check_role(["manage_speakers"]))
+):
+    new_speaker = SpeakerModel(**speaker.dict())
+    db.add(new_speaker)
+    db.commit()
+    db.refresh(new_speaker)
+    return new_speaker
+
+@router.get("/", response_model=list[SpeakerSchema])
+def list_speakers(db: Session = Depends(get_db)):
+    return db.query(SpeakerModel).all()
+
+@router.get("/{speaker_id}", response_model=SpeakerSchema)
+def get_speaker(speaker_id: int, db: Session = Depends(get_db)):
+    speaker = db.query(SpeakerModel).filter_by(id=speaker_id).first()
+    if not speaker:
+        raise HTTPException(status_code=404, detail="Speaker not found")
+    return speaker
+
+@router.put("/{speaker_id}", response_model=SpeakerSchema)
+def update_speaker(
+    speaker_id: int,
+    speaker_data: SpeakerCreate,
+    db: Session = Depends(get_db),
+    user: dict = Depends(check_role(["manage_speakers"]))
+):
+    speaker = db.query(SpeakerModel).filter_by(id=speaker_id).first()
+    if not speaker:
+        raise HTTPException(status_code=404, detail="Speaker not found")
+    
+    for key, value in speaker_data.dict().items():
+        setattr(speaker, key, value)
+
+    db.commit()
+    db.refresh(speaker)
+    return speaker
+
+@router.delete("/{speaker_id}", response_model=SpeakerSchema)
+def delete_speaker(
+    speaker_id: int,
+    db: Session = Depends(get_db),
+    user: dict = Depends(check_role(["manage_speakers"]))
+):
+    speaker = db.query(SpeakerModel).filter_by(id=speaker_id).first()
+    if not speaker:
+        raise HTTPException(status_code=404, detail="Speaker not found")
+
+    db.delete(speaker)
+    db.commit()
+    return speaker

--- a/router/speaker.py
+++ b/router/speaker.py
@@ -12,7 +12,7 @@ router = Router()
 def create_speaker(
     speaker: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["manage_speakers", "organizer"]))
 ):
     new_speaker = SpeakerModel(**speaker.dict())
     db.add(new_speaker)
@@ -36,7 +36,7 @@ def update_speaker(
     speaker_id: int,
     speaker_data: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["manage_speakers", "organizer"]))
 ):
     speaker = db.query(SpeakerModel).filter_by(id=speaker_id).first()
     if not speaker:
@@ -53,7 +53,7 @@ def update_speaker(
 def delete_speaker(
     speaker_id: int,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["manage_speakers", "organizer"]))
 ):
     speaker = db.query(SpeakerModel).filter_by(id=speaker_id).first()
     if not speaker:

--- a/schemas/speaker.py
+++ b/schemas/speaker.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+class SpeakerBase(BaseModel):
+    name: str
+    description: str
+    image: str
+
+class SpeakerCreate(SpeakerBase):
+    pass
+
+class Speaker(SpeakerBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/schemas/speaker_component.py
+++ b/schemas/speaker_component.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+from schemas.ui.page import BaseComponentSchema
+
+
+class SpeakerComponent(BaseComponentSchema):
+    name: str = Field(..., description="Speaker name")
+    description: str = Field(..., description="Speaker description")
+    image: str = Field(..., description="Speaker image URL")


### PR DESCRIPTION
This pull request introduces a new speaker presentation plugin with models, schemas, and routes to manage speaker data. The most important changes include the registration of the plugin, the definition of the speaker model and schemas, and the implementation of CRUD operations for speakers.

Plugin registration and routing:

* [`__init__.py`](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR1-R19): Added functions to register and unregister the speaker presentation plugin, which registers the `SpeakerComponent` and returns the router.
* [`router/__init__.py`](diffhunk://#diff-b4dbaace8ef74fe84717a8932062e85c956f485809802b155d18f39eee3f03ceR1-R7): Set up a new router and included the speaker router under the `/speakers` path.

Speaker model and schemas:

* [`models/speaker.py`](diffhunk://#diff-13c547f9d99ff436e75bae4b166e49df3df5f0e6e5c962cc5c887b941bfdaa24R1-R10): Defined the `Speaker` model with fields for id, name, description, and image.
* [`schemas/speaker.py`](diffhunk://#diff-01a43505c46df998a154225721f6e8ab6a89d71a0e6cbae9b9bbb1c9ac9af07aR1-R15): Created Pydantic schemas for `SpeakerBase`, `SpeakerCreate`, and `Speaker`, including the necessary fields and configurations.
* [`schemas/speaker_component.py`](diffhunk://#diff-f4c4e0acc39712cadd3ccd78563000544cf672460c8b0c3f15e410f841862360R1-R8): Defined the `SpeakerComponent` schema for the speaker component with fields for name, description, and image.

CRUD operations for speakers:

* [`router/speaker.py`](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcR1-R64): Implemented CRUD endpoints for creating, listing, retrieving, updating, and deleting speakers, with appropriate dependencies and error handling.