### PR TITLE
Fixes and updates

### DIFF
--- a/router/speaker.py
+++ b/router/speaker.py
@@ -100,23 +100,3 @@ def delete_speaker(
     db.delete(speaker)
     db.commit()
     return speaker
-
-@router.delete("/{speaker_id}/image", response_model=SpeakerSchema)
-def remove_speaker_image(
-    speaker_id: int,
-    db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
-):
-    speaker = db.query(SpeakerModel).filter_by(id=speaker_id).first()
-    if not speaker:
-        raise HTTPException(status_code=404, detail="Speaker not found")
-
-    if is_valid_uuid(speaker.image):
-        MediaService.unregister(db, speaker.image, force=True)
-    else:
-        raise HTTPException(status_code=404, detail="Current image is external or was not found")
-
-    speaker.image = None
-    db.commit()
-    db.refresh(speaker)
-    return speaker

--- a/router/speaker.py
+++ b/router/speaker.py
@@ -73,7 +73,7 @@ def partial_update_speaker(
     speaker_id: int,
     speaker_data: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     """Update a speaker"""
     try:
@@ -91,7 +91,7 @@ def partial_update_speaker(
     speaker_id: int,
     speaker_data: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     """Partially update a speaker"""
     try:
@@ -126,7 +126,7 @@ def delete_speaker(
 def remove_speaker_image(
     speaker_id: int,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     """Remove a speaker's image"""
     try:

--- a/router/speaker.py
+++ b/router/speaker.py
@@ -16,7 +16,7 @@ router = Router()
 def create_speaker(
     speaker: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     image = speaker.image
 
@@ -53,7 +53,7 @@ def update_speaker(
     speaker_id: int,
     speaker_data: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     speaker = db.query(SpeakerModel).filter_by(id=speaker_id).first()
     if not speaker:
@@ -88,7 +88,7 @@ def update_speaker(
 def delete_speaker(
     speaker_id: int,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     speaker = db.query(SpeakerModel).filter_by(id=speaker_id).first()
     if not speaker:


### PR DESCRIPTION
This pull request modifies role dependencies for speaker management endpoints and removes an unused endpoint for deleting a speaker's image. These changes improve role specificity and simplify the codebase.

### Role Dependency Updates:
* Updated the role dependency in the `create_speaker`, `update_speaker`, and `delete_speaker` functions to use `cb-manage_speakers` instead of `manage_speakers` in `router/speaker.py`. This ensures proper role-based access control. [[1]](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL19-R19) [[2]](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL56-R56) [[3]](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL91-R91)

### Codebase Simplification:
* Removed the `remove_speaker_image` endpoint from `router/speaker.py`. This endpoint was responsible for deleting a speaker's image but was deemed unnecessary or unused.