### PR TITLE
role fix

### DIFF
--- a/router/speaker.py
+++ b/router/speaker.py
@@ -14,7 +14,7 @@ router = Router()
 def create_speaker(
     speaker: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     """Create a new speaker"""
     try:
@@ -55,7 +55,7 @@ def update_speaker(
     speaker_id: int,
     speaker_data: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     """Update a speaker"""
     try:
@@ -73,7 +73,7 @@ def partial_update_speaker(
     speaker_id: int,
     speaker_data: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     """Partially update a speaker"""
     try:
@@ -90,7 +90,7 @@ def partial_update_speaker(
 def delete_speaker(
     speaker_id: int,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     """Delete a speaker"""
     try:
@@ -108,7 +108,7 @@ def delete_speaker(
 def remove_speaker_image(
     speaker_id: int,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["manage_speakers"]))
+    user: dict = Depends(check_role(["cb-manage_speakers"]))
 ):
     """Remove a speaker's image"""
     try:


### PR DESCRIPTION
This pull request updates role-based access control for speaker-related operations in the `router/speaker.py` file. The role required for these operations has been changed from `manage_speakers` to `cb-manage_speakers`.

### Role-based access control updates:

* Updated the `create_speaker` function to require the `cb-manage_speakers` role instead of `manage_speakers`. (`router/speaker.py`, [router/speaker.pyL17-R17](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL17-R17))
* Updated the `update_speaker` function to require the `cb-manage_speakers` role instead of `manage_speakers`. (`router/speaker.py`, [router/speaker.pyL58-R58](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL58-R58))
* Updated the `partial_update_speaker` function to require the `cb-manage_speakers` role instead of `manage_speakers`. (`router/speaker.py`, [router/speaker.pyL76-R76](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL76-R76))
* Updated the `delete_speaker` function to require the `cb-manage_speakers` role instead of `manage_speakers`. (`router/speaker.py`, [router/speaker.pyL93-R93](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL93-R93))
* Updated the `remove_speaker_image` function to require the `cb-manage_speakers` role instead of `manage_speakers`. (`router/speaker.py`, [router/speaker.pyL111-R111](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL111-R111))