### PR TITLE
Scrum 273 add role to speakers in plugin frontend form and app component

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,6 @@ import logging
 
 logger = logging.getLogger("coffeebreak.speaker")
 
-PLUGIN_TITLE = "speaker-presentation-plugin"
 NAME = "Speaker Presentation"
 DESCRIPTION = "A plugin for presenting speakers in a conference or event setting."
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 logger = logging.getLogger("coffeebreak.speaker")
 
-NAME = "Speaker Presentation"
+NAME = "Speaker Presentation Plugin"
 DESCRIPTION = "A plugin for presenting speakers in a conference or event setting."
 
 async def register_plugin():

--- a/models/speaker.py
+++ b/models/speaker.py
@@ -6,6 +6,7 @@ class Speaker(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(255), nullable=False, index=True)
-    description = Column(Text, nullable=False)
+    role = Column(String(255), nullable=True)
+    description = Column(Text, nullable=True)
     image = Column(String, nullable=True)
     activity_id = Column(Integer, ForeignKey("activities.id"), nullable=True)

--- a/router/speaker.py
+++ b/router/speaker.py
@@ -14,7 +14,7 @@ router = Router()
 def create_speaker(
     speaker: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["cb-manage_speakers"]))
+    user: dict = Depends(check_role(["manage_speakers"]))
 ):
     """Create a new speaker"""
     try:
@@ -55,7 +55,7 @@ def update_speaker(
     speaker_id: int,
     speaker_data: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["cb-manage_speakers"]))
+    user: dict = Depends(check_role(["manage_speakers"]))
 ):
     """Update a speaker"""
     try:
@@ -73,7 +73,7 @@ def partial_update_speaker(
     speaker_id: int,
     speaker_data: SpeakerCreate,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["cb-manage_speakers"]))
+    user: dict = Depends(check_role(["manage_speakers"]))
 ):
     """Partially update a speaker"""
     try:
@@ -90,7 +90,7 @@ def partial_update_speaker(
 def delete_speaker(
     speaker_id: int,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["cb-manage_speakers"]))
+    user: dict = Depends(check_role(["manage_speakers"]))
 ):
     """Delete a speaker"""
     try:
@@ -108,7 +108,7 @@ def delete_speaker(
 def remove_speaker_image(
     speaker_id: int,
     db: Session = Depends(get_db),
-    user: dict = Depends(check_role(["cb-manage_speakers"]))
+    user: dict = Depends(check_role(["manage_speakers"]))
 ):
     """Remove a speaker's image"""
     try:

--- a/schemas/speaker.py
+++ b/schemas/speaker.py
@@ -3,12 +3,14 @@ from typing import Optional
 
 class SpeakerBase(BaseModel):
     name: str = Field(..., max_length=255)
-    description: str
+    role: str = None
+    description: str = None
     image: Optional[str] = None
     activity_id: Optional[int] = None
 
 class SpeakerCreate(BaseModel):
     name: str
+    role: str = None
     description: str = None
     image: Optional[str] = None
     activity_id: Optional[int] = None

--- a/services/speaker_service.py
+++ b/services/speaker_service.py
@@ -51,6 +51,7 @@ class SpeakerService:
         # Create speaker
         new_speaker = SpeakerModel(
             name=speaker_data.name,
+            role=speaker_data.role,
             description=speaker_data.description,
             image=image,
             activity_id=speaker_data.activity_id
@@ -119,6 +120,7 @@ class SpeakerService:
         speaker_copy = SpeakerModel(
             id=speaker.id,
             name=speaker.name,
+            role=speaker.role,
             description=speaker.description,
             image=speaker.image,
             activity_id=speaker.activity_id


### PR DESCRIPTION
This pull request introduces several updates to enhance the speaker management functionality in the application. The changes include schema and database model updates to support a new `role` field for speakers, adjustments to user role checks for API endpoints, and minor improvements to naming conventions for consistency.

### Schema and Model Updates:
* Added a new `role` field to the `Speaker` database model in `models/speaker.py`. This field is optional and allows specifying a speaker's role. The `description` field is now also optional.
* Updated `schemas/speaker.py` to include the optional `role` field in both `SpeakerBase` and `SpeakerCreate` schemas.
* Modified `services/speaker_service.py` to handle the new `role` field when creating and deleting speakers. [[1]](diffhunk://#diff-c0747a4102df95e5242a2d422f821e355af058a0b4a596c5cac886f331998b1aR54) [[2]](diffhunk://#diff-c0747a4102df95e5242a2d422f821e355af058a0b4a596c5cac886f331998b1aR123)

### API Role Check Updates:
* Replaced the role check dependency `cb-manage_speakers` with `manage_speakers` in all speaker-related API endpoints in `router/speaker.py` for consistency and clarity. [[1]](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL17-R17) [[2]](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL58-R58) [[3]](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL76-R76) [[4]](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL93-R93) [[5]](diffhunk://#diff-ad672c32565363bf184b5c6c4226294e39208c683cc74a0d1ebd252fa7945cdcL111-R111)

### Naming Convention Improvement:
* Updated the `NAME` constant in `__init__.py` to "Speaker Presentation Plugin" for better alignment with naming conventions.