### PR TITLE
add socials to speaker

### DIFF
--- a/models/speaker.py
+++ b/models/speaker.py
@@ -10,3 +10,7 @@ class Speaker(Base):
     description = Column(Text, nullable=True)
     image = Column(String, nullable=True)
     activity_id = Column(Integer, ForeignKey("activities.id"), nullable=True)
+    linkedin = Column(String(255), nullable=True)
+    facebook = Column(String(255), nullable=True)
+    instagram = Column(String(255), nullable=True)
+    youtube = Column(String(255), nullable=True)

--- a/schemas/speaker.py
+++ b/schemas/speaker.py
@@ -7,6 +7,12 @@ class SpeakerBase(BaseModel):
     description: str = None
     image: Optional[str] = None
     activity_id: Optional[int] = None
+    # social media links
+    linkedin: Optional[str] = None
+    facebook: Optional[str] = None
+    instagram: Optional[str] = None
+    youtube: Optional[str] = None
+    
 
 class SpeakerCreate(BaseModel):
     name: str
@@ -14,6 +20,10 @@ class SpeakerCreate(BaseModel):
     description: str = None
     image: Optional[str] = None
     activity_id: Optional[int] = None
+    linkedin: Optional[str] = None
+    facebook: Optional[str] = None
+    instagram: Optional[str] = None
+    youtube: Optional[str] = None
 
 class Speaker(SpeakerBase):
     id: int

--- a/services/speaker_service.py
+++ b/services/speaker_service.py
@@ -54,7 +54,11 @@ class SpeakerService:
             role=speaker_data.role,
             description=speaker_data.description,
             image=image,
-            activity_id=speaker_data.activity_id
+            activity_id=speaker_data.activity_id,
+            linkedin=speaker_data.linkedin,
+            facebook=speaker_data.facebook,
+            instagram=speaker_data.instagram,
+            youtube=speaker_data.youtube
         )
         
         self.db.add(new_speaker)
@@ -123,7 +127,11 @@ class SpeakerService:
             role=speaker.role,
             description=speaker.description,
             image=speaker.image,
-            activity_id=speaker.activity_id
+            activity_id=speaker.activity_id,
+            linkedin=speaker.linkedin,
+            facebook=speaker.facebook,
+            instagram=speaker.instagram,
+            youtube=speaker.youtube
         )
         
         self.db.delete(speaker)


### PR DESCRIPTION
This pull request adds support for storing and managing social media links for speakers in the application. The changes include updates to the database model, schemas, and service layer to handle new fields for social media links such as LinkedIn, Facebook, Instagram, and YouTube.

### Database Model Updates:
* [`models/speaker.py`](diffhunk://#diff-13c547f9d99ff436e75bae4b166e49df3df5f0e6e5c962cc5c887b941bfdaa24R13-R16): Added new columns `linkedin`, `facebook`, `instagram`, and `youtube` to the `Speaker` model to store social media links.

### Schema Updates:
* [`schemas/speaker.py`](diffhunk://#diff-01a43505c46df998a154225721f6e8ab6a89d71a0e6cbae9b9bbb1c9ac9af07aR10-R26): Updated `SpeakerBase`, `SpeakerCreate`, and `Speaker` schemas to include optional fields for `linkedin`, `facebook`, `instagram`, and `youtube`.

### Service Layer Updates:
* [`services/speaker_service.py`](diffhunk://#diff-c0747a4102df95e5242a2d422f821e355af058a0b4a596c5cac886f331998b1aL57-R61): Updated the `create` method to handle the new social media fields when creating a speaker.
* [`services/speaker_service.py`](diffhunk://#diff-c0747a4102df95e5242a2d422f821e355af058a0b4a596c5cac886f331998b1aL126-R134): Updated the `delete` method to include social media fields when returning the deleted speaker's details.

**Related Jira Ticket:** SCRUM-383