### PR TITLE
Hotfix/add socials

### DIFF
--- a/models/speaker.py
+++ b/models/speaker.py
@@ -10,3 +10,7 @@ class Speaker(Base):
     description = Column(Text, nullable=True)
     image = Column(String, nullable=True)
     activity_id = Column(Integer, ForeignKey("activities.id"), nullable=True)
+    linkedin = Column(String(255), nullable=True)
+    facebook = Column(String(255), nullable=True)
+    instagram = Column(String(255), nullable=True)
+    youtube = Column(String(255), nullable=True)

--- a/schemas/speaker.py
+++ b/schemas/speaker.py
@@ -7,6 +7,12 @@ class SpeakerBase(BaseModel):
     description: str = None
     image: Optional[str] = None
     activity_id: Optional[int] = None
+    # social media links
+    linkedin: Optional[str] = None
+    facebook: Optional[str] = None
+    instagram: Optional[str] = None
+    youtube: Optional[str] = None
+    
 
 class SpeakerCreate(BaseModel):
     name: str
@@ -14,6 +20,10 @@ class SpeakerCreate(BaseModel):
     description: str = None
     image: Optional[str] = None
     activity_id: Optional[int] = None
+    linkedin: Optional[str] = None
+    facebook: Optional[str] = None
+    instagram: Optional[str] = None
+    youtube: Optional[str] = None
 
 class Speaker(SpeakerBase):
     id: int

--- a/services/speaker_service.py
+++ b/services/speaker_service.py
@@ -54,7 +54,11 @@ class SpeakerService:
             role=speaker_data.role,
             description=speaker_data.description,
             image=image,
-            activity_id=speaker_data.activity_id
+            activity_id=speaker_data.activity_id,
+            linkedin=speaker_data.linkedin,
+            facebook=speaker_data.facebook,
+            instagram=speaker_data.instagram,
+            youtube=speaker_data.youtube
         )
         
         self.db.add(new_speaker)
@@ -123,7 +127,11 @@ class SpeakerService:
             role=speaker.role,
             description=speaker.description,
             image=speaker.image,
-            activity_id=speaker.activity_id
+            activity_id=speaker.activity_id,
+            linkedin=speaker.linkedin,
+            facebook=speaker.facebook,
+            instagram=speaker.instagram,
+            youtube=speaker.youtube
         )
         
         self.db.delete(speaker)


### PR DESCRIPTION
This pull request introduces support for managing social media links for speakers by adding fields for LinkedIn, Facebook, Instagram, and YouTube. The changes span the database model, schema, and service layer to ensure proper handling of these new fields.

### Database Model Updates:
* Added `linkedin`, `facebook`, `instagram`, and `youtube` fields to the `Speaker` model in `models/speaker.py`. These fields are optional and have a maximum length of 255 characters.

### Schema Updates:
* Updated the `SpeakerBase` and `SpeakerCreate` schemas in `schemas/speaker.py` to include the new social media fields as optional attributes.

### Service Layer Updates:
* Modified the `create` method in `services/speaker_service.py` to handle the new social media fields when creating a speaker.
* Updated the `delete` method in `services/speaker_service.py` to ensure the new social media fields are properly included in the speaker object before deletion.

**Related Jira Ticket:** SCRUM-382