### PR TITLE
feat: add pyproject.toml manifest and simplify plugin init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,22 +1,11 @@
 from .router import router
 from .schemas.speaker_component import SpeakerComponent
 from coffeebreak import ComponentRegistry
-import logging
 
-logger = logging.getLogger("coffeebreak.speaker")
 
-NAME = "Speaker Presentation Plugin"
-DESCRIPTION = "A plugin for presenting speakers in a conference or event setting."
-
-async def register_plugin():
+def REGISTER():
     ComponentRegistry.register_component(SpeakerComponent)
-    logger.debug("Speaker presentation plugin registered.")
 
-async def unregister_plugin():
+
+def UNREGISTER():
     ComponentRegistry.unregister_component("SpeakerComponent")
-    logger.debug("Speaker presentation plugin unregistered.")
-
-REGISTER = register_plugin
-UNREGISTER = unregister_plugin
-
-CONFIG_PAGE = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.coffeebreak]
+identifier = "speaker-presentation-plugin"
+name = "Speaker Presentation Plugin"
+description = "A plugin for presenting speakers in a conference or event setting."
+config_page = true


### PR DESCRIPTION
## Summary
- Added `pyproject.toml` with `[tool.coffeebreak]` manifest for plugin metadata
- Simplified `__init__.py` — removed metadata constants, logger, and async wrappers
- Metadata is now handled by the core automatically via the manifest